### PR TITLE
podnet_plus fixups

### DIFF
--- a/cmd/kubelet-netbinder/bin/pod-remove-local-network.sh
+++ b/cmd/kubelet-netbinder/bin/pod-remove-local-network.sh
@@ -22,3 +22,13 @@ ovs-ofctl del-flows -O OpenFlow13 obr0 "table=0,cookie=${netid}/0xffffffff,in_po
 ovs-ofctl del-flows -O OpenFlow13 obr0 "table=1,cookie=${netid}/0xffffffff,tun_id=${netid},dl_dst=${mac}"
 # rule to respond to arp requests that come locally from this host
 ovs-ofctl del-flows -O OpenFlow13 obr0 "table=1,cookie=${netid}/0xffffffff,tun_id=${netid},dl_type=0x0806,nw_dst=${ip}"
+
+# We don't get the docker ID here so we have to find it ourselves
+CONTAINERS=`grep -m1 -riIl "HOSTNAME=${pod_name}" /var/lib/docker/execdriver/native/ | sed 's/\/container.json//g'`
+for cdir in $CONTAINERS; do
+	veth_host=`jq .network_state.veth_host ${cdir}/state.json | tr -d '"'`
+	if [ -n $veth_host -a "$veth_host" != "null" ]; then
+		ovs-vsctl del-port obr0 $veth_host
+	fi
+done
+

--- a/cmd/kubelet-netbinder/netbinder.go
+++ b/cmd/kubelet-netbinder/netbinder.go
@@ -60,7 +60,7 @@ func newVnidInfo(vnid string) (*vnidInfo) {
 
 func init() {
 	flag.Var(&etcdServerList, "etcd_servers", "List of etcd servers to watch (http://ip:port), comma separated (optional).")
-	exec.New().Command("ovs-vsctl", "add-port", "tap1", "obr0", "--", "set", "Interface", "tap1", "ofport_request=3").CombinedOutput()
+	exec.New().Command("ovs-vsctl", "add-port", "obr0", "tap1", "--", "set", "Interface", "tap1", "ofport_request=3", "type=internal").CombinedOutput()
 	exec.New().Command("ip", "addr", "add", "10.246.1.1/16", "dev", "tap1").CombinedOutput()
 	exec.New().Command("ip", "link", "set", "dev", "tap1", "up").CombinedOutput()
 	exec.New().Command("ovs-ofctl", "del-flows", "-O", "OpenFlow13", "obr0").CombinedOutput()
@@ -191,7 +191,8 @@ func WatchLoop(w watch.Interface, netinfo *vnidInfo) {
 		case event, ok := <-w.ResultChan():
 			fmt.Printf("Got an event : %v\n", event)
 			if !ok {
-				continue
+				go watchVnid(netinfo)
+				return
 			}
 			handleVnidEvent(event, netinfo)
 		}

--- a/cmd/kubelet/bin/pod-set-local-network.sh
+++ b/cmd/kubelet/bin/pod-set-local-network.sh
@@ -26,7 +26,7 @@ if [ "$docker_id" != "" ]; then
 	nsenter -n -t $pid -- ip link set dev eth0 addr $mac
 	nsenter -n -t $pid -- ip addr add ${ip}/24 dev eth0
 	nsenter -n -t $pid -- ip link set dev eth0 up
-	nsenter -n -t $pid -- ip route set default via 10.246.1.1 dev eth0
+	nsenter -n -t $pid -- ip route replace default via 10.246.1.1 dev eth0
 fi
 
 ## add flows


### PR DESCRIPTION
1) remove the veth from the ovs bridge, otherwise they pile up and the ovsdb
keeps a record of them on restart

2) make tap1 an 'internal' port and fix the ordering of arguments

3) fix 'ip route' usage (should be 'add' or 'replace')
